### PR TITLE
Pinned all dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,27 +27,27 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "canvas": "~1.1.1",
-    "noflo": "~0.5.11",
-    "noflo-adapters": "^0.1.3",
-    "noflo-core": "^0.1.11",
+    "canvas": "1.1.6",
+    "noflo": "0.5.13",
+    "noflo-adapters": "0.1.3",
+    "noflo-core": "0.1.14",
     "noflo-helper-arrayable": "git+https://git@github.com/noflo/noflo-helper-arrayable.git",
-    "noflo-objects": "^0.1.12"
+    "noflo-objects": "0.1.12"
   },
   "devDependencies": {
-    "chai": "~1.9.0",
-    "grunt": "~0.4.1",
-    "grunt-cafe-mocha": "~0.1.2",
-    "grunt-coffeelint": "~0.0.6",
-    "grunt-contrib-coffee": "~0.11.1",
-    "grunt-contrib-connect": "^0.7.1",
-    "grunt-contrib-uglify": "~0.6.0",
-    "grunt-contrib-watch": "~0.6.1",
-    "grunt-mocha-phantomjs": "~0.6.0",
-    "grunt-noflo-browser": "^0.1.2",
-    "grunt-noflo-manifest": "^0.1.5",
-    "mocha": "~1.21.0",
-    "sinon": "^1.10.3"
+    "chai": "1.9.2",
+    "grunt": "0.4.5",
+    "grunt-cafe-mocha": "0.1.13",
+    "grunt-coffeelint": "0.0.13",
+    "grunt-contrib-coffee": "0.11.1",
+    "grunt-contrib-connect": "0.7.1",
+    "grunt-contrib-uglify": "0.6.0",
+    "grunt-contrib-watch": "0.6.1",
+    "grunt-mocha-phantomjs": "0.6.2",
+    "grunt-noflo-browser": "0.1.11",
+    "grunt-noflo-manifest": "0.1.11",
+    "mocha": "1.21.5",
+    "sinon": "1.17.0"
   },
   "keywords": [],
   "noflo": {


### PR DESCRIPTION
:wave: Hello!

We’re all trying to keep our software up to date, yet stable at the same time.

This is the first in a series of automatic PRs to help you achieve this goal. It pins all of the dependencies in your `package.json`, so you have complete control over the exact state of your software.

From now on you’ll receive PRs whenever one of your dependencies updates – in real time. This way you get all the benefits of up-to-date dependencies, while having them pinned at the same time. This means:

- No more surprises because some of your dependencies didn’t follow [SemVer](http://semver.org/). Your software is always in a state you know about, regardless of _when_ someone does `$ npm install`.
- If you have continuous integration set up for this repo, it’ll run automatically. Ideally, it will pass and you'll stay up to date with the press of a button. If the updated dependency _does_ break your software, it won’t affect your users, because their dependencies are still pinned to the working state.
- You can immediately identify which dependency updates break your software, because each one is tested in isolation. You’ll also have a branch ready to work on, so adapting to new APIs is way faster.

Merge this PR and you’ll have up-to-date software without the headaches :sparkles:

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>